### PR TITLE
Use ${file.separator} instead of hardcoded slash

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>javax.xml.ws</groupId>
+      <artifactId>com.springsource.javax.xml.ws</artifactId>
+      <version>2.1.1</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
   <url>http://maven.apache.org</url>
 
   <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit.version>3.8.1</junit.version>
     <java.version>1.8</java.version>
     <mycbr.version>3.3-SNAPSHOT</mycbr.version>
@@ -80,13 +81,6 @@
       <artifactId>json-simple</artifactId>
       <version>1.1.1</version>
     </dependency>
-      <dependency>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-          <version>RELEASE</version>
-          <scope>test</scope>
-      </dependency>
-
   </dependencies>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <repositories>
     <repository>
       <id>mycbr-repo</id>
-      <url>file://${basedir}/lib</url>
+      <url>file://${basedir}${file.separator}lib</url>
     </repository>
 
     <repository>


### PR DESCRIPTION
On windows ${basedir} contains backwards-slashes instead of forward-slashes.
If they are mixed, the repo can not be compiled.

Also set encoding to UTF-8 (causes warning on windows without it being set)

Lastly, removed duplicate junit dependency (removes a warning) and included javax.xml.ws as a dependency (not included in all JDKs)