### PR TITLE
Fix adding instance with sub-concept

### DIFF
--- a/src/main/java/no/ntnu/mycbr/rest/controller/CaseController.java
+++ b/src/main/java/no/ntnu/mycbr/rest/controller/CaseController.java
@@ -76,6 +76,7 @@ public class CaseController
 		return false;
 	} else {
 		p.getCaseBases().get(casebaseID).removeCase(caseID);
+		p.save();
 		return true;
 	}
     }
@@ -123,6 +124,8 @@ public class CaseController
 			if(instance.getConcept().getName().contentEquals(conceptID))
 				p.getConceptByID(conceptID).removeInstance(instance.getName());
 		}
+		p.save();
+		System.out.println("Deleted all instances of concept: " + conceptID);
 		return true;
 	}
 
@@ -151,13 +154,16 @@ public class CaseController
 	    @PathVariable(value=CASEBASE_ID) String casebaseID) {
 
 	Project p = App.getProject();
+	p.save();
 	if(!p.getCaseBases().containsKey(casebaseID))
 	    return false;
 	Collection<Instance> collection = p.getCaseBases().get(casebaseID).getCases();
 	for(Instance i : collection){
 		p.getCaseBases().get(casebaseID).removeCase(i.getName());
 	 }
-
+	System.out.println("Current project: " + p.getProject().getName());
+	p.getProject().save();
+	System.out.println("Deleted all instances of casebase: " + casebaseID);
 	return true;
     }
 

--- a/src/main/java/no/ntnu/mycbr/rest/controller/service/CaseService.java
+++ b/src/main/java/no/ntnu/mycbr/rest/controller/service/CaseService.java
@@ -37,16 +37,16 @@ public class CaseService {
 
                 if (attributeDesc.isMultiple()) {
                    LinkedList<Attribute> attLL = new LinkedList<Attribute>();
-                    SymbolDesc aSym = (SymbolDesc) c.getAttributeDesc(strKey);
+                   AttributeDesc aSym = c.getAttributeDesc(strKey);
 
                     StringTokenizer st = new StringTokenizer(inpcase.get(key).toString(), ",");
+
                     while (st.hasMoreElements()){
                         String symbolName = st.nextElement().toString().trim();
                         attLL.add(aSym.getAttribute(symbolName));
                     }
-                    MultipleAttribute<SymbolDesc> multiSymbol = new MultipleAttribute<SymbolDesc>(aSym, attLL);
+                    MultipleAttribute<AttributeDesc> multiSymbol = new MultipleAttribute<>(aSym, attLL);
                     instance.addAttribute(aSym, multiSymbol);
-
                 } else {
                     instance.addAttribute(attributeDesc, inpcase.get(key));
                 }
@@ -101,8 +101,8 @@ public class CaseService {
             logger.error("got exception while trying to add instances",e);
             return null;
         }
-        //p.save();
-        //System.out.println("saved project to: " + p.getPath());
+        p.save();
+        System.out.println("saved project to: " + p.getPath());
         return ret;
     }
     public ArrayList<String> addInstances(Concept c, String casebaseID, JSONArray inpcases){


### PR DESCRIPTION
This PR fixes the problem of not being able to add a concept with attributes that are other concepts.

The error was the use of a child class (SymbolDesc) rather than the superclass (AttributeDesc).

Also adds save calls.