### PR TITLE
Fix retrieval with subconcept

### DIFF
--- a/src/main/java/no/ntnu/mycbr/rest/common/ApiOperationConstants.java
+++ b/src/main/java/no/ntnu/mycbr/rest/common/ApiOperationConstants.java
@@ -86,7 +86,7 @@ public interface ApiOperationConstants {
             GET_SIMILAR_CASES_BY_CASE_ID_WITH_CONTENT = "getSimilarCasesByCaseIDWithContent",
 
     GET_SIMILAR_CASES_BY_ATTRIBUTE = "getSimilarCasesByAttribute",
-            GET_SIMILAR_CASES_BY_MULTIPLE_ATTRIBUTES = "getSimilarCasesByMultipleAttributess",
+            GET_SIMILAR_CASES_BY_MULTIPLE_ATTRIBUTES = "getSimilarCasesByMultipleAttributes",
 
     GET_CASE_BASE_SELF_SIMILARITY = "getCaseBaseSelfSimilarity";
 

--- a/src/main/java/no/ntnu/mycbr/rest/controller/RetrievalController.java
+++ b/src/main/java/no/ntnu/mycbr/rest/controller/RetrievalController.java
@@ -172,7 +172,7 @@ public class RetrievalController {
             @PathVariable(value = CASEBASE_ID) String casebaseID,
             @PathVariable(value = AMAL_FUNCTION_ID) String amalgamationFunctionID,
             @RequestParam(required = false, value = NO_OF_RETURNED_CASES, defaultValue = DEFAULT_NO_OF_CASES) int k,
-            @RequestBody(required = true) HashMap<String, Object> attributeNameValueMap) {
+            @RequestBody() HashMap<String, Object> attributeNameValueMap) {
 
         Query query = new Query(casebaseID, conceptID, amalgamationFunctionID, attributeNameValueMap, k);
         return getFullResult(query, conceptID);
@@ -189,8 +189,7 @@ public class RetrievalController {
             @RequestParam(required = false, value = NO_OF_RETURNED_CASES, defaultValue = DEFAULT_NO_OF_CASES) int k) {
 
         Query query = new Query(casebaseID, conceptID, amalgamationFunctionID, caseID, k);
-        List<LinkedHashMap<String, String>> cases = getFullResult(query, conceptID);
-        return cases;
+		return getFullResult(query, conceptID);
     }
 
     @ApiOperation(value = GET_SIMILAR_CASES_WITH_CONTENT, nickname = GET_SIMILAR_CASES_WITH_CONTENT)

--- a/src/main/java/no/ntnu/mycbr/rest/controller/RetrievalController.java
+++ b/src/main/java/no/ntnu/mycbr/rest/controller/RetrievalController.java
@@ -1,27 +1,20 @@
 package no.ntnu.mycbr.rest.controller;
 
-import org.springframework.web.bind.annotation.RestController;
-
 import io.swagger.annotations.ApiOperation;
 import no.ntnu.mycbr.rest.common.ApiResponseAnnotations.ApiResponsesDefault;
 import no.ntnu.mycbr.rest.controller.helper.Query;
-import no.ntnu.mycbr.rest.controller.service.AnalyticsService;
 import no.ntnu.mycbr.rest.controller.service.SelfSimilarityRetrieval;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.springframework.web.bind.annotation.*;
-import java.util.*;
 import org.json.simple.JSONArray;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.*;
 
-import static no.ntnu.mycbr.rest.utils.QueryUtils.getFullResult;
-
-import static no.ntnu.mycbr.rest.common.ApiPathConstants.*;
-import static no.ntnu.mycbr.rest.controller.service.AnalyticsService.*;
 import static no.ntnu.mycbr.rest.common.ApiOperationConstants.*;
+import static no.ntnu.mycbr.rest.common.ApiPathConstants.*;
 import static no.ntnu.mycbr.rest.utils.QueryUtils.getFullResult;
 
 
@@ -35,7 +28,7 @@ public class RetrievalController {
     private static final String RETRIEVAL_BY_MULTIPLE_ATTRIBUTES = "/retrievalByMultipleAttributes";
     private static final String RETRIEVAL_BY_CASE_ID_WITH_CONTENT = "/retrievalByCaseIDWithContent";
     private static final String RETRIEVAL_WITH_CONTENT = "/retrievalWithContent";
-    
+
     private static final String VW = "vw";
     private static final String CAR0 = "car0";
     private static final String MANUFACTURER = "manufacturer";
@@ -43,197 +36,200 @@ public class RetrievalController {
 
     /**
      * Redundant code
-     * @deprecated use {@link #getSimilarInstancesWithContent(String, String, String, int, HashMap)} instead.  
+     *
+     * @deprecated use {@link #getSimilarInstancesWithContent(String, String, String, int, HashMap)} instead.
      */
     @Deprecated
-    @ApiOperation(value = "use: "+GET_SIMILAR_CASES_BY_MULTIPLE_ATTRIBUTES, nickname = "use: "+GET_SIMILAR_CASES_BY_MULTIPLE_ATTRIBUTES)
-    @RequestMapping(method = RequestMethod.POST, path=PATH_CONCEPT_CASEBASE_ID+RETRIEVAL, produces=APPLICATION_JSON)
+    @ApiOperation(value = "use: " + GET_SIMILAR_CASES_BY_MULTIPLE_ATTRIBUTES, nickname = "use: " + GET_SIMILAR_CASES_BY_MULTIPLE_ATTRIBUTES)
+    @RequestMapping(method = RequestMethod.POST, path = PATH_CONCEPT_CASEBASE_ID + RETRIEVAL, produces = APPLICATION_JSON)
     @ApiResponsesDefault
     public Query getSimilarInstances(
-	    @RequestParam(value=CASEBASE, defaultValue=DEFAULT_CASEBASE) String casebase,
-	    @RequestParam(value=CONCEPT_ID, defaultValue=DEFAULT_CONCEPT) String concept,
-	    @RequestParam(value=AMAL_FUNCTION, defaultValue=DEFAULT_AMAL_FUNCTION) String amalFunc,
-	    @RequestParam(required = false, value=NO_OF_RETURNED_CASES,defaultValue = DEFAULT_NO_OF_CASES) int k,
-	    @RequestBody(required = true) HashMap<String, Object> queryContent) {
-	
-	return new Query(casebase, concept, amalFunc, queryContent, k);
+            @RequestParam(value = CASEBASE, defaultValue = DEFAULT_CASEBASE) String casebase,
+            @RequestParam(value = CONCEPT_ID, defaultValue = DEFAULT_CONCEPT) String concept,
+            @RequestParam(value = AMAL_FUNCTION, defaultValue = DEFAULT_AMAL_FUNCTION) String amalFunc,
+            @RequestParam(required = false, value = NO_OF_RETURNED_CASES, defaultValue = DEFAULT_NO_OF_CASES) int k,
+            @RequestBody(required = true) HashMap<String, Object> queryContent) {
+
+        return new Query(casebase, concept, amalFunc, queryContent, k);
     }
 
     @ApiOperation(value = GET_SIMILAR_CASES_BY_CASE_ID, nickname = GET_SIMILAR_CASES_BY_CASE_ID)
-    @RequestMapping(method = RequestMethod.GET, path=PATH_CONCEPT_CASEBASE_AMAL_FUNCTION_ID+RETRIEVAL_BY_CASE_ID, produces=APPLICATION_JSON)
+    @RequestMapping(method = RequestMethod.GET, path = PATH_CONCEPT_CASEBASE_AMAL_FUNCTION_ID + RETRIEVAL_BY_CASE_ID, produces = APPLICATION_JSON)
     @ApiResponsesDefault
     public Map<String, Double> getSimilarCasesByID(
-	    @PathVariable(value=CONCEPT_ID) String conceptID,
-	    @PathVariable(value=CASEBASE_ID) String casebaseID,
-	    @PathVariable(value=AMAL_FUNCTION_ID) String amalgamationFunctionID,
-	    @RequestParam(value=CASE_ID) String caseID,
-	    @RequestParam(required = false, value=NO_OF_RETURNED_CASES,defaultValue = DEFAULT_NO_OF_CASES) int k) {
-	
-	Query query = new Query(casebaseID, conceptID, amalgamationFunctionID, caseID, k);
-	
-	return query.getSimilarCases();
+            @PathVariable(value = CONCEPT_ID) String conceptID,
+            @PathVariable(value = CASEBASE_ID) String casebaseID,
+            @PathVariable(value = AMAL_FUNCTION_ID) String amalgamationFunctionID,
+            @RequestParam(value = CASE_ID) String caseID,
+            @RequestParam(required = false, value = NO_OF_RETURNED_CASES, defaultValue = DEFAULT_NO_OF_CASES) int k) {
+
+        Query query = new Query(casebaseID, conceptID, amalgamationFunctionID, caseID, k);
+
+        return query.getSimilarCases();
     }
 
     @ApiOperation(value = GET_SIMILAR_CASES_BY_MULTIPLE_CASE_IDS, nickname = GET_SIMILAR_CASES_BY_MULTIPLE_CASE_IDS)
-    @RequestMapping(method = RequestMethod.POST, path=PATH_CONCEPT_CASEBASE_AMAL_FUNCTION_ID+RETRIEVAL_BY_MULTIPLE_CASE_I_DS, produces=APPLICATION_JSON)
+    @RequestMapping(method = RequestMethod.POST, path = PATH_CONCEPT_CASEBASE_AMAL_FUNCTION_ID + RETRIEVAL_BY_MULTIPLE_CASE_I_DS, produces = APPLICATION_JSON)
     @ApiResponsesDefault
     public Map<String, HashMap<String, Double>> getSimilarCasesByIDs(
-	    @PathVariable(value=CONCEPT_ID) String conceptID,
-	    @PathVariable(value=CASEBASE_ID) String casebaseIDs,
-	    @PathVariable(value=AMAL_FUNCTION_ID) String amalgamationFunctionID,
-	    @RequestParam(required = false, value=NO_OF_RETURNED_CASES,defaultValue = DEFAULT_NO_OF_CASES) int k,
-	    @RequestBody(required = true)  Set<String> caseIDs) {
-	
-	Map<String, HashMap<String, Double>> retrievedResult  = Query.retrieve(casebaseIDs, conceptID, amalgamationFunctionID, caseIDs, k);
-	
-	return retrievedResult;
+            @PathVariable(value = CONCEPT_ID) String conceptID,
+            @PathVariable(value = CASEBASE_ID) String casebaseIDs,
+            @PathVariable(value = AMAL_FUNCTION_ID) String amalgamationFunctionID,
+            @RequestParam(required = false, value = NO_OF_RETURNED_CASES, defaultValue = DEFAULT_NO_OF_CASES) int k,
+            @RequestBody(required = true) Set<String> caseIDs) {
+
+        Map<String, HashMap<String, Double>> retrievedResult = Query.retrieve(casebaseIDs, conceptID, amalgamationFunctionID, caseIDs, k);
+
+        return retrievedResult;
     }
 
     /**
      * Redundant code
-     * @deprecated use {@see no.ntnu.mycbr.rest.controller.EphemeralController#retrievalFromEphemeralCaseBaseWithContent(String, String, String, String, int, Set)} instead. 
+     *
+     * @deprecated use {@see no.ntnu.mycbr.rest.controller.EphemeralController#retrievalFromEphemeralCaseBaseWithContent(String, String, String, String, int, Set)} instead.
      */
     @Deprecated
-    @ApiOperation(value = "use: "+ GET_SIMILAR_CASES_FROM_EPHEMERAL_CASE_BASE_WITH_CONTENT, nickname = "use: "+ GET_SIMILAR_CASES_FROM_EPHEMERAL_CASE_BASE_WITH_CONTENT)
-    @RequestMapping(method = RequestMethod.GET, path=PATH_CONCEPT_CASEBASE_ID+"/retrievalByIDInIDs", produces=APPLICATION_JSON)
+    @ApiOperation(value = "use: " + GET_SIMILAR_CASES_FROM_EPHEMERAL_CASE_BASE_WITH_CONTENT, nickname = "use: " + GET_SIMILAR_CASES_FROM_EPHEMERAL_CASE_BASE_WITH_CONTENT)
+    @RequestMapping(method = RequestMethod.GET, path = PATH_CONCEPT_CASEBASE_ID + "/retrievalByIDInIDs", produces = APPLICATION_JSON)
     @ApiResponsesDefault
-    public HashMap<String, HashMap<String,Double>> getSimilarInstancesByIDWithinIDs(
-	    @PathVariable(value=CONCEPT_ID) String conceptID,
-	    @PathVariable(value=CASEBASE_ID) String casebaseID,
-	    @RequestParam(required = true)  Set<String> caseIDs,
-	    @RequestParam(value="filterCaseIDs", defaultValue = "[caseID1, caseID2, caseID3]") String filterCaseIDs,
-	    @RequestParam(required = false, value=NO_OF_RETURNED_CASES,defaultValue = DEFAULT_NO_OF_CASES) int k) {
-	
-	JSONParser parser = new JSONParser();
-	ArrayList<String> queryBaseIDs = new ArrayList<>();
-	JSONArray queryBase = null;
-	try {
-	    queryBase = (JSONArray) parser.parse(filterCaseIDs);
-	} catch (ParseException e) {
-	    e.printStackTrace();
-	}
-	Iterator<String>  it = queryBase.iterator();
-	it = queryBase.iterator();
-	while(it.hasNext())
-	    queryBaseIDs.add(it.next());
-	return Query.retrieve(casebaseID, conceptID, null, caseIDs, queryBaseIDs, k);
+    public HashMap<String, HashMap<String, Double>> getSimilarInstancesByIDWithinIDs(
+            @PathVariable(value = CONCEPT_ID) String conceptID,
+            @PathVariable(value = CASEBASE_ID) String casebaseID,
+            @RequestParam(required = true) Set<String> caseIDs,
+            @RequestParam(value = "filterCaseIDs", defaultValue = "[caseID1, caseID2, caseID3]") String filterCaseIDs,
+            @RequestParam(required = false, value = NO_OF_RETURNED_CASES, defaultValue = DEFAULT_NO_OF_CASES) int k) {
+
+        JSONParser parser = new JSONParser();
+        ArrayList<String> queryBaseIDs = new ArrayList<>();
+        JSONArray queryBase = null;
+        try {
+            queryBase = (JSONArray) parser.parse(filterCaseIDs);
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+        Iterator<String> it = queryBase.iterator();
+        it = queryBase.iterator();
+        while (it.hasNext())
+            queryBaseIDs.add(it.next());
+        return Query.retrieve(casebaseID, conceptID, null, caseIDs, queryBaseIDs, k);
     }
 
     /**
      * Redundant code
-     * @deprecated use {@see no.ntnu.mycbr.rest.controller.EphemeralController#retrievalFromEphemeralCaseBase(String, String, String, int, Map)} instead.  
+     *
+     * @deprecated use {@see no.ntnu.mycbr.rest.controller.EphemeralController#retrievalFromEphemeralCaseBase(String, String, String, int, Map)} instead.
      */
     @Deprecated
-    @ApiOperation(value = "use: "+ GET_SIMILAR_CASES_FROM_EPHEMERAL_CASE_BASE, nickname = "use: "+ GET_SIMILAR_CASES_FROM_EPHEMERAL_CASE_BASE)
-    @RequestMapping(method = RequestMethod.GET, path=PATH_CONCEPT_CASEBASE_ID+"/retrievalByIDsInIDs", produces=APPLICATION_JSON)
+    @ApiOperation(value = "use: " + GET_SIMILAR_CASES_FROM_EPHEMERAL_CASE_BASE, nickname = "use: " + GET_SIMILAR_CASES_FROM_EPHEMERAL_CASE_BASE)
+    @RequestMapping(method = RequestMethod.GET, path = PATH_CONCEPT_CASEBASE_ID + "/retrievalByIDsInIDs", produces = APPLICATION_JSON)
     @ApiResponsesDefault
-    public HashMap<String, HashMap<String,Double>> getSimilarInstancesByIDsWithinIDs(
-	    @PathVariable(value=CONCEPT_ID) String conceptID,
-	    @PathVariable(value=CASEBASE_ID) String casebaseID,
-	    @RequestParam(required = true)  Set<String> caseIDs,
-	    @RequestParam(value="filterCaseIDs", defaultValue = "[caseID1, caseID2, caseID3]") String filterCaseIDs,
-	    @RequestParam(required = false, value=NO_OF_RETURNED_CASES,defaultValue = DEFAULT_NO_OF_CASES) int k) {
-	
-	ArrayList<String> caseIDList = new ArrayList<>();
-	JSONParser parser = new JSONParser();
-	JSONArray inpcases = null;
-	
-	Iterator<String>  it = inpcases.iterator();
-	while(it.hasNext())
-	    caseIDList.add(it.next());
-	ArrayList<String> queryBaseIDs = new ArrayList<>();
-	JSONArray queryBase = null;
-	try {
-	    queryBase = (JSONArray) parser.parse(filterCaseIDs);
-	} catch (ParseException e) {
-	    e.printStackTrace();
-	}
-	it = queryBase.iterator();
-	while(it.hasNext())
-	    queryBaseIDs.add(it.next());
-	return Query.retrieve(casebaseID, conceptID, null, caseIDs, queryBaseIDs, k);
+    public HashMap<String, HashMap<String, Double>> getSimilarInstancesByIDsWithinIDs(
+            @PathVariable(value = CONCEPT_ID) String conceptID,
+            @PathVariable(value = CASEBASE_ID) String casebaseID,
+            @RequestParam(required = true) Set<String> caseIDs,
+            @RequestParam(value = "filterCaseIDs", defaultValue = "[caseID1, caseID2, caseID3]") String filterCaseIDs,
+            @RequestParam(required = false, value = NO_OF_RETURNED_CASES, defaultValue = DEFAULT_NO_OF_CASES) int k) {
+
+        ArrayList<String> caseIDList = new ArrayList<>();
+        JSONParser parser = new JSONParser();
+        JSONArray inpcases = null;
+
+        Iterator<String> it = inpcases.iterator();
+        while (it.hasNext())
+            caseIDList.add(it.next());
+        ArrayList<String> queryBaseIDs = new ArrayList<>();
+        JSONArray queryBase = null;
+        try {
+            queryBase = (JSONArray) parser.parse(filterCaseIDs);
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+        it = queryBase.iterator();
+        while (it.hasNext())
+            queryBaseIDs.add(it.next());
+        return Query.retrieve(casebaseID, conceptID, null, caseIDs, queryBaseIDs, k);
     }
 
     @ApiOperation(value = GET_SIMILAR_CASES_BY_ATTRIBUTE, nickname = GET_SIMILAR_CASES_BY_ATTRIBUTE)
-    @RequestMapping(method = RequestMethod.GET, path=PATH_CONCEPT_CASEBASE_AMAL_FUNCTION_ID+RETRIEVAL_BY_ATTRIBUTE, produces=APPLICATION_JSON)
+    @RequestMapping(method = RequestMethod.GET, path = PATH_CONCEPT_CASEBASE_AMAL_FUNCTION_ID + RETRIEVAL_BY_ATTRIBUTE, produces = APPLICATION_JSON)
     @ApiResponsesDefault
     public Query getSimilarInstancesByAttribute(
-	    @PathVariable(value=CONCEPT_ID) String conceptID,
-	    @PathVariable(value=CASEBASE_ID) String casebaseID,
-	    @PathVariable(value=AMAL_FUNCTION_ID) String amalgamationFunctionID,
-	    @RequestParam(value="Symbol attribute name", defaultValue=MANUFACTURER) String attribute,
-	    @RequestParam(value=VALUE, defaultValue=VW) String value,
-	    @RequestParam(required = false, value=NO_OF_RETURNED_CASES,defaultValue = DEFAULT_NO_OF_CASES) int k) {
-	
-	return new Query(casebaseID, conceptID, amalgamationFunctionID, attribute, value, k);
+            @PathVariable(value = CONCEPT_ID) String conceptID,
+            @PathVariable(value = CASEBASE_ID) String casebaseID,
+            @PathVariable(value = AMAL_FUNCTION_ID) String amalgamationFunctionID,
+            @RequestParam(value = "Symbol attribute name", defaultValue = MANUFACTURER) String attribute,
+            @RequestParam(value = VALUE, defaultValue = VW) String value,
+            @RequestParam(required = false, value = NO_OF_RETURNED_CASES, defaultValue = DEFAULT_NO_OF_CASES) int k) {
+
+        return new Query(casebaseID, conceptID, amalgamationFunctionID, attribute, value, k);
     }
 
     @ApiOperation(value = GET_SIMILAR_CASES_BY_MULTIPLE_ATTRIBUTES, nickname = GET_SIMILAR_CASES_BY_MULTIPLE_ATTRIBUTES)
-    @RequestMapping(method = RequestMethod.POST, path=PATH_CONCEPT_CASEBASE_AMAL_FUNCTION_ID+RETRIEVAL_BY_MULTIPLE_ATTRIBUTES, produces=APPLICATION_JSON)
+    @RequestMapping(method = RequestMethod.POST, path = PATH_CONCEPT_CASEBASE_AMAL_FUNCTION_ID + RETRIEVAL_BY_MULTIPLE_ATTRIBUTES, produces = APPLICATION_JSON)
     @ApiResponsesDefault
     public @ResponseBody List<LinkedHashMap<String, String>> getSimilarInstancesWithContent(
-	    @PathVariable(value=CONCEPT_ID) String conceptID,
-	    @PathVariable(value=CASEBASE_ID) String casebaseID,
-	    @PathVariable(value=AMAL_FUNCTION_ID) String amalgamationFunctionID,
-	    @RequestParam(required = false, value=NO_OF_RETURNED_CASES,defaultValue = DEFAULT_NO_OF_CASES) int k,
-	    @RequestBody(required = true)  HashMap<String, Object> attributeNameValueMap) {
+            @PathVariable(value = CONCEPT_ID) String conceptID,
+            @PathVariable(value = CASEBASE_ID) String casebaseID,
+            @PathVariable(value = AMAL_FUNCTION_ID) String amalgamationFunctionID,
+            @RequestParam(required = false, value = NO_OF_RETURNED_CASES, defaultValue = DEFAULT_NO_OF_CASES) int k,
+            @RequestBody(required = true) HashMap<String, Object> attributeNameValueMap) {
 
-	Query query = new Query(casebaseID, conceptID, amalgamationFunctionID, attributeNameValueMap, k);
-	List<LinkedHashMap<String, String>> cases = getFullResult(query, conceptID);
-	return cases;
+        Query query = new Query(casebaseID, conceptID, amalgamationFunctionID, attributeNameValueMap, k);
+        return getFullResult(query, conceptID);
     }
 
     @ApiOperation(value = GET_SIMILAR_CASES_BY_CASE_ID_WITH_CONTENT, nickname = GET_SIMILAR_CASES_BY_CASE_ID_WITH_CONTENT)
-    @RequestMapping(method = RequestMethod.GET, path=PATH_CONCEPT_CASEBASE_AMAL_FUNCTION_ID+RETRIEVAL_BY_CASE_ID_WITH_CONTENT, produces=APPLICATION_JSON)
+    @RequestMapping(method = RequestMethod.GET, path = PATH_CONCEPT_CASEBASE_AMAL_FUNCTION_ID + RETRIEVAL_BY_CASE_ID_WITH_CONTENT, produces = APPLICATION_JSON)
     @ApiResponsesDefault
     public @ResponseBody List<LinkedHashMap<String, String>> getSimilarInstancesByIDWithContent(
-	    @PathVariable(value=CONCEPT_ID) String conceptID,
-	    @PathVariable(value=CASEBASE_ID) String casebaseID,
-	    @PathVariable(value=AMAL_FUNCTION_ID) String amalgamationFunctionID,
-	    @RequestParam(value=CASE_ID, defaultValue=CAR0) String caseID,
-	    @RequestParam(required = false, value=NO_OF_RETURNED_CASES,defaultValue = DEFAULT_NO_OF_CASES) int k) {
+            @PathVariable(value = CONCEPT_ID) String conceptID,
+            @PathVariable(value = CASEBASE_ID) String casebaseID,
+            @PathVariable(value = AMAL_FUNCTION_ID) String amalgamationFunctionID,
+            @RequestParam(value = CASE_ID, defaultValue = CAR0) String caseID,
+            @RequestParam(required = false, value = NO_OF_RETURNED_CASES, defaultValue = DEFAULT_NO_OF_CASES) int k) {
 
-	Query query = new Query(casebaseID, conceptID, amalgamationFunctionID, caseID, k);
-	List<LinkedHashMap<String, String>> cases = getFullResult(query, conceptID);
-	return cases;
+        Query query = new Query(casebaseID, conceptID, amalgamationFunctionID, caseID, k);
+        List<LinkedHashMap<String, String>> cases = getFullResult(query, conceptID);
+        return cases;
     }
 
     @ApiOperation(value = GET_SIMILAR_CASES_WITH_CONTENT, nickname = GET_SIMILAR_CASES_WITH_CONTENT)
-    @RequestMapping(method = RequestMethod.GET, path=PATH_CONCEPT_CASEBASE_ID+RETRIEVAL_WITH_CONTENT, produces=APPLICATION_JSON)
+    @RequestMapping(method = RequestMethod.GET, path = PATH_CONCEPT_CASEBASE_ID + RETRIEVAL_WITH_CONTENT, produces = APPLICATION_JSON)
     @ApiResponsesDefault
     public @ResponseBody List<LinkedHashMap<String, String>> getSimilarInstancesByAttributeWithContent(
-	    @PathVariable(value=CONCEPT_ID) String conceptID,
-	    @PathVariable(value=CASEBASE_ID) String casebaseID,
-	    @RequestParam(value=AMAL_FUNCTION_ID, defaultValue=DEFAULT_AMAL_FUNCTION) String amalgamationFunctionID,
-	    @RequestParam(value="Symbol attribute name", defaultValue=MANUFACTURER) String attribute,
-	    @RequestParam(value=VALUE, defaultValue=VW) String value,
-	    @RequestParam(required = false, value=NO_OF_RETURNED_CASES,defaultValue = DEFAULT_NO_OF_CASES) int k) {
+            @PathVariable(value = CONCEPT_ID) String conceptID,
+            @PathVariable(value = CASEBASE_ID) String casebaseID,
+            @RequestParam(value = AMAL_FUNCTION_ID, defaultValue = DEFAULT_AMAL_FUNCTION) String amalgamationFunctionID,
+            @RequestParam(value = "Symbol attribute name", defaultValue = MANUFACTURER) String attribute,
+            @RequestParam(value = VALUE, defaultValue = VW) String value,
+            @RequestParam(required = false, value = NO_OF_RETURNED_CASES, defaultValue = DEFAULT_NO_OF_CASES) int k) {
 
-	Query query = new Query(casebaseID, conceptID, amalgamationFunctionID, attribute, value, k);
-	List<LinkedHashMap<String, String>> cases = getFullResult(query, conceptID);
-	return cases;
+        Query query = new Query(casebaseID, conceptID, amalgamationFunctionID, attribute, value, k);
+        List<LinkedHashMap<String, String>> cases = getFullResult(query, conceptID);
+        return cases;
     }
 
     /**
      * Retrieval of similarity values for all the cases of the case base, where every case is queried to the case base.
-     * @param conceptID: The name of the case base used in the myCBR project
-     * @param casebaseID: The name of the concept used in the myCBR project
+     *
+     * @param conceptID:              The name of the case base used in the myCBR project
+     * @param casebaseID:             The name of the concept used in the myCBR project
      * @param amalgamationFunctionID: Amalgamation function or Global Similarity Function that is used in global similarity computation
-     * @param k: Number of retrieved cases desired by the user. Default value is -1, which means return all the cases.
-     * @return A matrix of similarity values, where the rows and columns are case IDs. The data structure is map of maps. 
+     * @param k:                      Number of retrieved cases desired by the user. Default value is -1, which means return all the cases.
+     * @return A matrix of similarity values, where the rows and columns are case IDs. The data structure is map of maps.
      */
     @ApiOperation(value = GET_CASE_BASE_SELF_SIMILARITY, nickname = GET_CASE_BASE_SELF_SIMILARITY)
-    @RequestMapping(method = RequestMethod.GET, path=PATH_CONCEPT_CASEBASE_SELF_SIMLARITY, produces=APPLICATION_JSON)
+    @RequestMapping(method = RequestMethod.GET, path = PATH_CONCEPT_CASEBASE_SELF_SIMLARITY, produces = APPLICATION_JSON)
     @ApiResponsesDefault
     public Map<String, Map<String, Double>> getCaseBaseSelfSimilarity(
-	    @PathVariable(value=CONCEPT_ID) String conceptID,
-	    @PathVariable(value=CASEBASE_ID) String casebaseID,	    
-	    @RequestParam(required = false, value=AMAL_FUNCTION_ID) String amalgamationFunctionID,
-	    @RequestParam(required = false, value=NO_OF_RETURNED_CASES, defaultValue = DEFAULT_NO_OF_CASES) int k) {
-	
-	Map<String, Map<String,Double>> retrivalResults =  new SelfSimilarityRetrieval()
-		.performSelfSimilarityRetrieval(conceptID, casebaseID, amalgamationFunctionID, k);
-	
-	return retrivalResults;
+            @PathVariable(value = CONCEPT_ID) String conceptID,
+            @PathVariable(value = CASEBASE_ID) String casebaseID,
+            @RequestParam(required = false, value = AMAL_FUNCTION_ID) String amalgamationFunctionID,
+            @RequestParam(required = false, value = NO_OF_RETURNED_CASES, defaultValue = DEFAULT_NO_OF_CASES) int k) {
+
+        Map<String, Map<String, Double>> retrivalResults = new SelfSimilarityRetrieval()
+                .performSelfSimilarityRetrieval(conceptID, casebaseID, amalgamationFunctionID, k);
+
+        return retrivalResults;
     }
 }

--- a/src/main/java/no/ntnu/mycbr/rest/controller/helper/Case.java
+++ b/src/main/java/no/ntnu/mycbr/rest/controller/helper/Case.java
@@ -8,7 +8,8 @@ import no.ntnu.mycbr.rest.cbr.CBREngine;
 
 import java.util.LinkedHashMap;
 
-import static no.ntnu.mycbr.rest.utils.Constants.*;
+import static no.ntnu.mycbr.rest.utils.Constants.CASE_ID;
+import static no.ntnu.mycbr.rest.utils.Constants.SIMILARITY;
 import static no.ntnu.mycbr.rest.utils.Helper.getSortedCaseContent;
 
 /**
@@ -17,12 +18,13 @@ import static no.ntnu.mycbr.rest.utils.Helper.getSortedCaseContent;
 public class Case {
 
     private LinkedHashMap<String, String> casecontent = new LinkedHashMap<String, String>();
+
     public Case(String caseID) {
 
         Project project = App.getProject();
         Concept concept = project.getConceptByID(CBREngine.getConceptName());
         Instance instance = concept.getInstance(caseID);
-        if(instance != null)
+        if (instance != null)
             casecontent = new LinkedHashMap<>(getSortedCaseContent(instance));
         else
             casecontent = new LinkedHashMap<>();
@@ -33,14 +35,13 @@ public class Case {
         Project project = App.getProject();
         Concept concept = project.getConceptByID(conceptID);
         Instance instance = concept.getInstance(caseID);
-        
+
         casecontent.put(CASE_ID, instance.getName());
         casecontent.putAll(getSortedCaseContent(instance));
     }
 
     // Used by full results
     public Case(String conceptID, String caseID, double similarity) {
-
         Project project = App.getProject();
         Concept concept = project.getConceptByID(conceptID);
         Instance instance = concept.getInstance(caseID);

--- a/src/main/java/no/ntnu/mycbr/rest/controller/helper/Query.java
+++ b/src/main/java/no/ntnu/mycbr/rest/controller/helper/Query.java
@@ -136,26 +136,20 @@ public class Query implements RetrievalCustomer {
             ConceptDesc conceptDesc = (ConceptDesc) attDesc;
             LinkedHashMap<?, ?> subConcepts = (LinkedHashMap<?, ?>) attr.getValue();
             LinkedList<Attribute> instances = new LinkedList<>();
-            if (!conceptDesc.isMultiple()) {
-                assert subConcepts.size() == 1 : "Subconcept should have only one entry when subconcept is not multiple";
-                String instanceId = (String) subConcepts.keySet().toArray()[0];
+            for (Map.Entry<?, ?> subConceptAttrEntry : subConcepts.entrySet()) {
+                String instanceId = (String) subConceptAttrEntry.getKey();
                 Instance newInstance = (Instance) attDesc.getAttribute(instanceId);
-                LinkedHashMap<?, ?> instanceAttr = (LinkedHashMap<?, ?>) subConcepts.get(instanceId);
+                Object instanceAttrMap = subConceptAttrEntry.getValue();
+                LinkedHashMap<?, ?> instanceAttr = (LinkedHashMap<?, ?>) instanceAttrMap;
                 for (Map.Entry<?, ?> instanceEntry : instanceAttr.entrySet()) {
                     this.addAttrToInstance((Map.Entry<String, Object>) instanceEntry, newInstance.getConcept(), newInstance);
                 }
-                query.addAttribute(conceptDesc, newInstance);
+                instances.add(newInstance);
+            }
+            if (!conceptDesc.isMultiple()) {
+                assert instances.size() == 1 : "Concept has more than 1 subconcept instance when multiple is false"
+                query.addAttribute(conceptDesc, instances.get(0));
             } else {
-                for (Map.Entry<?, ?> subConceptAttrEntry : subConcepts.entrySet()) {
-                    String instanceId = (String) subConceptAttrEntry.getKey();
-                    Instance newInstance = (Instance) attDesc.getAttribute(instanceId);
-                    Object instanceAttrMap = subConceptAttrEntry.getValue();
-                    LinkedHashMap<?, ?> instanceAttr = (LinkedHashMap<?, ?>) instanceAttrMap;
-                    for (Map.Entry<?, ?> instanceEntry : instanceAttr.entrySet()) {
-                        this.addAttrToInstance((Map.Entry<String, Object>) instanceEntry, newInstance.getConcept(), newInstance);
-                    }
-                    instances.add(newInstance);
-                }
                 MultipleAttribute<ConceptDesc> multiSubConcept = new MultipleAttribute<>(conceptDesc, instances);
                 query.addAttribute(conceptDesc, multiSubConcept);
             }

--- a/src/main/java/no/ntnu/mycbr/rest/controller/helper/Query.java
+++ b/src/main/java/no/ntnu/mycbr/rest/controller/helper/Query.java
@@ -6,20 +6,26 @@ import no.ntnu.mycbr.core.Project;
 import no.ntnu.mycbr.core.casebase.Attribute;
 import no.ntnu.mycbr.core.casebase.Instance;
 import no.ntnu.mycbr.core.casebase.MultipleAttribute;
-import no.ntnu.mycbr.core.model.*;
-//import no.ntnu.mycbr.core.retrieval.NeuralRetrieval;
+import no.ntnu.mycbr.core.model.AttributeDesc;
+import no.ntnu.mycbr.core.model.Concept;
+import no.ntnu.mycbr.core.model.ConceptDesc;
+import no.ntnu.mycbr.core.model.SymbolDesc;
 import no.ntnu.mycbr.core.retrieval.Retrieval;
 import no.ntnu.mycbr.core.retrieval.Retrieval.RetrievalCustomer;
 import no.ntnu.mycbr.core.retrieval.RetrievalResult;
 import no.ntnu.mycbr.core.similarity.Similarity;
 import no.ntnu.mycbr.rest.App;
 import no.ntnu.mycbr.rest.utils.ConcurrentCustomer;
-import no.ntnu.mycbr.util.Pair;
-import no.ntnu.mycbr.rest.utils.TemporaryAmalgamFctNotChangedException;
 import no.ntnu.mycbr.rest.utils.TemporaryAmalgamFctManager;
+import no.ntnu.mycbr.rest.utils.TemporaryAmalgamFctNotChangedException;
+import no.ntnu.mycbr.util.Pair;
 
+import java.text.ParseException;
 import java.util.*;
-import java.util.concurrent.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 /**
  * Created by kerstin on 05/08/16.
@@ -31,32 +37,34 @@ public class Query implements RetrievalCustomer {
     public Query(String casebase, String concept) {
         Project project = App.getProject();
         // create case bases and assign the case bases that will be used for submitting a query
-        DefaultCaseBase cb = (DefaultCaseBase)project.getCaseBases().get(casebase);
+        DefaultCaseBase cb = (DefaultCaseBase) project.getCaseBases().get(casebase);
         List<Instance> cases = (List<Instance>) cb.getCases();
 
         for (Instance c : cases) {
-            if(c.getConcept().getName().contentEquals(concept))
+            if (c.getConcept().getName().contentEquals(concept))
                 this.resultList.put(c.getName(), new Double(1.0));
         }
     }
+
     public Query(String concept) {
         Project project = App.getProject();
         // create case bases and assign the case bases that will be used for submitting a query
         HashMap<String, ICaseBase> cbs = project.getCaseBases();
         List<Instance> cases = new ArrayList<>();
-        for(ICaseBase iCaseBase : cbs.values()) {
-            cases.addAll( iCaseBase.getCases());
+        for (ICaseBase iCaseBase : cbs.values()) {
+            cases.addAll(iCaseBase.getCases());
         }
 
         for (Instance c : cases) {
             this.resultList.put(c.getName(), new Double(1.0));
         }
     }
+
     public Query(String casebase, String concept, String amalFunc, HashMap<String, Object> queryContent, int k) {
 
         Project project = App.getProject();
         // create case bases and assign the case bases that will be used for submitting a query
-        DefaultCaseBase cb = (DefaultCaseBase)project.getCaseBases().get(casebase);
+        DefaultCaseBase cb = (DefaultCaseBase) project.getCaseBases().get(casebase);
         // create a concept and get the main concept of the project;
         Concept myConcept = project.getConceptByID(concept);
 
@@ -65,84 +73,105 @@ public class Query implements RetrievalCustomer {
         try {
             tempAmalgamFctManager.changeAmalgamFct(amalFunc);
 
-            Retrieval r = new Retrieval(myConcept, cb,this);
-            //r.setRetrievalEngine(new Retrieval(project,r));
+            Retrieval r = new Retrieval(myConcept, cb, this);
+            Instance query = r.getQueryInstance();
 
-            try {
-                Instance query = r.getQueryInstance();
-
-                for (Map.Entry<String, Object> att : queryContent.entrySet()) {
-                    String name = att.getKey();
-                    AttributeDesc attdesc = myConcept.getAttributeDesc(name);
-                    if (attdesc.getClass().getSimpleName().equalsIgnoreCase("FloatDesc")){
-                        FloatDesc aFloatAtt = (FloatDesc) attdesc;
-                        query.addAttribute(attdesc, Float.parseFloat(att.getValue().toString()));
-                    }
-                    if (attdesc.getClass().getSimpleName().equalsIgnoreCase("IntegerDesc")){
-                        IntegerDesc aIntegerAtt = (IntegerDesc) attdesc;
-                        query.addAttribute(attdesc, Integer.parseInt(att.getValue().toString()));
-                    }
-                    if (attdesc.getClass().getSimpleName().equalsIgnoreCase("DoubleDesc")){
-                        DoubleDesc aIntegerAtt = (DoubleDesc) attdesc;
-                        query.addAttribute(attdesc, Double.parseDouble(att.getValue().toString()));
-                    }
-                    if (attdesc.getClass().getSimpleName().equalsIgnoreCase("SymbolDesc")){
-                        SymbolDesc aSymbolAtt = (SymbolDesc) attdesc;
-                        if (!aSymbolAtt.isMultiple()) {
-                            query.addAttribute(attdesc, (String) att.getValue());
-                        }
-                        else {
-                            LinkedList<Attribute> llAtts = new LinkedList<Attribute>();
-                            StringTokenizer st = new StringTokenizer((String) att.getValue(), ",");
-                            while (st.hasMoreElements()) {
-                                String symbolName = st.nextElement().toString().trim();
-                                llAtts.add(aSymbolAtt.getAttribute(symbolName));
-                            }
-
-                            MultipleAttribute<SymbolDesc> muliSymbol = new MultipleAttribute<SymbolDesc>(aSymbolAtt, llAtts);
-                            query.addAttribute(attdesc, muliSymbol);
-                        }
-                    }
-                }
-
-                if (k > -1) {
-                    r.setK(k);
-                    r.setRetrievalMethod(Retrieval.RetrievalMethod.RETRIEVE_K_SORTED);
-                } else {
-                    r.setRetrievalMethod(Retrieval.RetrievalMethod.RETRIEVE_SORTED);
-                }
-
-                r.start();
-                List<Pair<Instance, Similarity>> results = this.results;
-
-                for (Pair<Instance, Similarity> result : results) {
-                    this.resultList.put(result.getFirst().getName(), result.getSecond().getValue());
-                }
-
-                query.reset();
-
-            }
-            catch (Exception e) {
-                e.printStackTrace();
+            // Iterate through all attributes and add them to the query instance
+            for (Map.Entry<String, Object> att : queryContent.entrySet()) {
+                this.addAttrToInstance(att, myConcept, query);
             }
 
-        } catch (TemporaryAmalgamFctNotChangedException e) {
-            // Return empty result
-            return;
+            if (k > -1) {
+                r.setK(k);
+                r.setRetrievalMethod(Retrieval.RetrievalMethod.RETRIEVE_K_SORTED);
+            } else {
+                r.setRetrievalMethod(Retrieval.RetrievalMethod.RETRIEVE_SORTED);
+            }
+
+            r.start();
+            List<Pair<Instance, Similarity>> results = this.results;
+
+            for (Pair<Instance, Similarity> result : results) {
+                this.resultList.put(result.getFirst().getName(), result.getSecond().getValue());
+            }
+
+            query.reset();
+
+        } catch (ParseException | TemporaryAmalgamFctNotChangedException e) {
+            throw new RuntimeException(e);
         } finally {
             tempAmalgamFctManager.rollBack();
         }
     }
 
-    public static HashMap<String,HashMap<String,Double>> retrieve(String casebase,
-                                                                  String concept,
-                                                                  String amalFunc,
-                                                                  Set<String> caseIDs,
-                                                                  List<String> queryBase,
-                                                                  int k) {
+    private void addAttrToInstance(Map.Entry<String, Object> attr, Concept myConcept, Instance query) throws ParseException {
+        String name = attr.getKey();
+        AttributeDesc attDesc = myConcept.getAttributeDesc(name);
+        if (attDesc.getClass().getSimpleName().equalsIgnoreCase("FloatDesc")) {
+            query.addAttribute(attDesc, Float.parseFloat(attr.getValue().toString()));
+        }
+        if (attDesc.getClass().getSimpleName().equalsIgnoreCase("IntegerDesc")) {
+            query.addAttribute(attDesc, Integer.parseInt(attr.getValue().toString()));
+        }
+        if (attDesc.getClass().getSimpleName().equalsIgnoreCase("DoubleDesc")) {
+            query.addAttribute(attDesc, Double.parseDouble(attr.getValue().toString()));
+        }
+        if (attDesc.getClass().getSimpleName().equalsIgnoreCase("SymbolDesc")) {
+            SymbolDesc aSymbolAtt = (SymbolDesc) attDesc;
+            if (!aSymbolAtt.isMultiple()) {
+                query.addAttribute(attDesc, attr.getValue());
+            } else {
+                LinkedList<Attribute> llAtts = new LinkedList<>();
+                StringTokenizer st = new StringTokenizer((String) attr.getValue(), ",");
+                while (st.hasMoreElements()) {
+                    String symbolName = st.nextElement().toString().trim();
+                    llAtts.add(aSymbolAtt.getAttribute(symbolName));
+                }
+
+                MultipleAttribute<SymbolDesc> muliSymbol = new MultipleAttribute<>(aSymbolAtt, llAtts);
+                query.addAttribute(attDesc, muliSymbol);
+            }
+        }
+        if (attDesc.getClass().getSimpleName().equalsIgnoreCase("ConceptDesc")) {
+            ConceptDesc conceptDesc = (ConceptDesc) attDesc;
+            LinkedHashMap<?, ?> subConcepts = (LinkedHashMap<?, ?>) attr.getValue();
+            LinkedList<Attribute> instances = new LinkedList<>();
+            if (!conceptDesc.isMultiple()) {
+                assert subConcepts.size() == 1 : "Subconcept should have only one entry when subconcept is not multiple";
+                String instanceId = (String) subConcepts.keySet().toArray()[0];
+                Instance newInstance = (Instance) attDesc.getAttribute(instanceId);
+                LinkedHashMap<?, ?> instanceAttr = (LinkedHashMap<?, ?>) subConcepts.get(instanceId);
+                for (Map.Entry<?, ?> instanceEntry : instanceAttr.entrySet()) {
+                    this.addAttrToInstance((Map.Entry<String, Object>) instanceEntry, newInstance.getConcept(), newInstance);
+                }
+                query.addAttribute(conceptDesc, newInstance);
+            } else {
+                for (Map.Entry<?, ?> subConceptAttrEntry : subConcepts.entrySet()) {
+                    String instanceId = (String) subConceptAttrEntry.getKey();
+                    Instance newInstance = (Instance) attDesc.getAttribute(instanceId);
+                    Object instanceAttrMap = subConceptAttrEntry.getValue();
+                    LinkedHashMap<?, ?> instanceAttr = (LinkedHashMap<?, ?>) instanceAttrMap;
+                    for (Map.Entry<?, ?> instanceEntry : instanceAttr.entrySet()) {
+                        this.addAttrToInstance((Map.Entry<String, Object>) instanceEntry, newInstance.getConcept(), newInstance);
+                    }
+                    instances.add(newInstance);
+                }
+                MultipleAttribute<ConceptDesc> multiSubConcept = new MultipleAttribute<>(conceptDesc, instances);
+                query.addAttribute(conceptDesc, multiSubConcept);
+            }
+        }
+    }
+
+
+    public static HashMap<String, HashMap<String, Double>> retrieve(String casebase,
+                                                                    String concept,
+                                                                    String amalFunc,
+                                                                    Set<String> caseIDs,
+                                                                    List<String> queryBase,
+                                                                    int k) {
         Project project = App.getProject();
         // create case bases and assign the case bases that will be used for submitting a query
-        DefaultCaseBase ocb = (DefaultCaseBase)project.getCaseBases().get(casebase);
+        DefaultCaseBase ocb = (DefaultCaseBase) project.getCaseBases().get(casebase);
         DefaultCaseBase tcb = null;
         try {
             tcb = project.createDefaultCB("tempCB");
@@ -153,71 +182,72 @@ public class Query implements RetrievalCustomer {
         /*HashMap<String,Instance> instanceMap = .
                 collect(Collectors.
                         toMap(Instance::getName, i->i));*/
-        HashMap<String,Instance> instanceMap = instances.stream().collect(HashMap::new,
-                (m,c) -> m.put(c.getName(),c),
-                (m,u) -> {});
-        for(String queryBaseCase : queryBase){
-            if(instanceMap.containsKey(queryBaseCase)){
+        HashMap<String, Instance> instanceMap = instances.stream().collect(HashMap::new,
+                (m, c) -> m.put(c.getName(), c),
+                (m, u) -> {
+                });
+        for (String queryBaseCase : queryBase) {
+            if (instanceMap.containsKey(queryBaseCase)) {
                 tcb.addCase(instanceMap.get(queryBaseCase));
             }
         }
-        HashMap<String,HashMap<String,Double>> ret = retrieve("tempCB",concept,amalFunc,caseIDs,k);
+        HashMap<String, HashMap<String, Double>> ret = retrieve("tempCB", concept, amalFunc, caseIDs, k);
         project.deleteCaseBase("tempCB");
         return ret;
 
     }
-    public static HashMap<String,HashMap<String,Double>> retrieve(String casebase, String concept, String amalFunc, Set<String> caseIDs, int k) {
+
+    public static HashMap<String, HashMap<String, Double>> retrieve(String casebase, String concept, String amalFunc, Set<String> caseIDs, int k) {
         Project project = App.getProject();
         // create case bases and assign the case bases that will be used for submitting a query
-        DefaultCaseBase cb = (DefaultCaseBase)project.getCaseBases().get(casebase);
+        DefaultCaseBase cb = (DefaultCaseBase) project.getCaseBases().get(casebase);
         // create a concept and get the main concept of the project;
         Concept myConcept = project.getConceptByID(concept);
-        HashMap<String,HashMap<String,Double>> ret = new HashMap<String,HashMap<String,Double>>();
+        HashMap<String, HashMap<String, Double>> ret = new HashMap<String, HashMap<String, Double>>();
         ConcurrentCustomer concurrentCustomer = new ConcurrentCustomer();
         TemporaryAmalgamFctManager tempAmalgamFctManager = new TemporaryAmalgamFctManager(myConcept);
 
         try {
-            if(amalFunc!=null)
-        	tempAmalgamFctManager.changeAmalgamFct(amalFunc);
+            if (amalFunc != null)
+                tempAmalgamFctManager.changeAmalgamFct(amalFunc);
 
             ExecutorService executor = Executors.newFixedThreadPool(48);
             ArrayList<Retrieval> retrievalThreads = new ArrayList<>();
-            HashMap<String,Retrieval> retrievals = new HashMap<>();
+            HashMap<String, Retrieval> retrievals = new HashMap<>();
             //r.setRetrievalEngine(new NeuralRetrieval(project,r));
-            
-            for(String caseID : caseIDs) {
-                Retrieval r = new Retrieval(myConcept, cb,concurrentCustomer,caseID);
+
+            for (String caseID : caseIDs) {
+                Retrieval r = new Retrieval(myConcept, cb, concurrentCustomer, caseID);
                 //concurrentCustomer.addRetriever(r,caseID);
                 r.setK(k);
-                if(k>0){
+                if (k > 0) {
                     r.setRetrievalMethod(Retrieval.RetrievalMethod.RETRIEVE_K_SORTED);
                 }
                 try {
                     Instance query = r.getQueryInstance();
                     Instance caze = myConcept.getInstance(caseID);
-                    if(caze == null)
+                    if (caze == null)
                         throw new IllegalArgumentException("There is no such case in the casebase: " + caseID);
                     for (Map.Entry<AttributeDesc, Attribute> e : caze.getAttributes()
                             .entrySet()) {
                         query.addAttribute(e.getKey(), e.getValue());
                     }
-                    retrievals.put(caseID,r);
+                    retrievals.put(caseID, r);
                     retrievalThreads.add(r);
-                }
-                catch (Exception e) {
+                } catch (Exception e) {
                     e.printStackTrace();
                 }
             }
             List<Future<RetrievalResult>> futureList = executor.invokeAll(retrievalThreads);
-            for(Future<RetrievalResult> future : futureList){
+            for (Future<RetrievalResult> future : futureList) {
                 try {
                     RetrievalResult result = future.get();
-                    List<Pair<Instance,Similarity>> thisRetList = result.getResult();
-                    HashMap<String,Double> thismap = new HashMap<>();
-                    for(Pair<Instance,Similarity> p : thisRetList){
-                        thismap.put(p.getFirst().getName(),p.getSecond().getValue());
+                    List<Pair<Instance, Similarity>> thisRetList = result.getResult();
+                    HashMap<String, Double> thismap = new HashMap<>();
+                    for (Pair<Instance, Similarity> p : thisRetList) {
+                        thismap.put(p.getFirst().getName(), p.getSecond().getValue());
                     }
-                    ret.put(result.getRetrevalID(),thismap);
+                    ret.put(result.getRetrevalID(), thismap);
                 } catch (ExecutionException e) {
                     e.printStackTrace();
                 }
@@ -241,9 +271,7 @@ public class Query implements RetrievalCustomer {
 */
 
 
-
-        } catch (TemporaryAmalgamFctNotChangedException e )
-        {
+        } catch (TemporaryAmalgamFctNotChangedException e) {
 
         } catch (InterruptedException e) {
             e.printStackTrace();
@@ -256,17 +284,17 @@ public class Query implements RetrievalCustomer {
     public Query(String casebase, String concept, String amalFunc, String caseID, int k) {
         Project project = App.getProject();
         // create case bases and assign the case bases that will be used for submitting a query
-        DefaultCaseBase cb = (DefaultCaseBase)project.getCaseBases().get(casebase);
+        DefaultCaseBase cb = (DefaultCaseBase) project.getCaseBases().get(casebase);
         // create a concept and get the main concept of the project;
         Concept myConcept = project.getConceptByID(concept);
 
         // if an amalgamation Function is specified, set this amalgamation function for the retrieval - otherwise use the currently active function
-        if(!(amalFunc == null))
+        if (!(amalFunc == null))
             myConcept.setActiveAmalgamFct(project.getFct(amalFunc));
 
         try {
 
-            Retrieval r = new Retrieval(myConcept, cb,this);
+            Retrieval r = new Retrieval(myConcept, cb, this);
             if (k > 0) {
                 r.setK(k);
                 r.setRetrievalMethod(Retrieval.RetrievalMethod.RETRIEVE_K_SORTED);
@@ -275,37 +303,35 @@ public class Query implements RetrievalCustomer {
             }
             //r.setRetrievalEngine(new NeuralRetrieval(project,r));
 
-                Instance query = r.getQueryInstance();
+            Instance query = r.getQueryInstance();
 
-                Instance caze = myConcept.getInstance(caseID);
+            Instance caze = myConcept.getInstance(caseID);
 
-                for (Map.Entry<AttributeDesc, Attribute> e : caze.getAttributes()
-                        .entrySet()) {
-                    query.addAttribute(e.getKey(), e.getValue());
-                }
-
-                r.start();
-                List<Pair<Instance, Similarity>> results = this.results;
-
-                for (Pair<Instance, Similarity> result : results) {
-                    this.resultList.put(result.getFirst().getName(), result.getSecond().getValue());
-                }
-
-                query.reset();
+            for (Map.Entry<AttributeDesc, Attribute> e : caze.getAttributes()
+                    .entrySet()) {
+                query.addAttribute(e.getKey(), e.getValue());
             }
 
-            catch (Exception e) {
-                e.printStackTrace();
+            r.start();
+            List<Pair<Instance, Similarity>> results = this.results;
+
+            for (Pair<Instance, Similarity> result : results) {
+                this.resultList.put(result.getFirst().getName(), result.getSecond().getValue());
             }
+
+            query.reset();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     public Query(String casebase, String concept, String amalFunc, String attribute, String value, int k) {
 
         Project project = App.getProject();
         // create case bases and assign the case bases that will be used for submitting a query
-        DefaultCaseBase cb = (DefaultCaseBase)project.getCaseBases().get(casebase);
+        DefaultCaseBase cb = (DefaultCaseBase) project.getCaseBases().get(casebase);
         // create a concept and get the main concept of the project;
-        Concept myConcept = project.getConceptByID(concept) ;
+        Concept myConcept = project.getConceptByID(concept);
 
         TemporaryAmalgamFctManager tempAmalgamFctManager = new TemporaryAmalgamFctManager(myConcept);
 
@@ -336,8 +362,7 @@ public class Query implements RetrievalCustomer {
 
                 query.reset();
 
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 e.printStackTrace();
             }
 
@@ -348,18 +373,17 @@ public class Query implements RetrievalCustomer {
             tempAmalgamFctManager.rollBack();
         }
     }
-    
-    
+
 
     public LinkedHashMap<String, Double> getSimilarCases() {
         return resultList;
     }
 
-    List<Pair<Instance,Similarity>> results;
+    List<Pair<Instance, Similarity>> results;
 
     @Override
     public void addResults(Retrieval ret, List<Pair<Instance, Similarity>> results) {
 
-            this.results = results;
+        this.results = results;
     }
 }

--- a/src/main/java/no/ntnu/mycbr/rest/controller/helper/Query.java
+++ b/src/main/java/no/ntnu/mycbr/rest/controller/helper/Query.java
@@ -147,7 +147,7 @@ public class Query implements RetrievalCustomer {
                 instances.add(newInstance);
             }
             if (!conceptDesc.isMultiple()) {
-                assert instances.size() == 1 : "Concept has more than 1 subconcept instance when multiple is false"
+                assert instances.size() == 1 : "Concept has more than 1 subconcept instance when multiple is false";
                 query.addAttribute(conceptDesc, instances.get(0));
             } else {
                 MultipleAttribute<ConceptDesc> multiSubConcept = new MultipleAttribute<>(conceptDesc, instances);

--- a/src/main/java/no/ntnu/mycbr/rest/utils/QueryUtils.java
+++ b/src/main/java/no/ntnu/mycbr/rest/utils/QueryUtils.java
@@ -14,12 +14,15 @@ public class QueryUtils {
         List<LinkedHashMap<String, String>> cases = new ArrayList<>();
 
         for (Map.Entry<String, Double> entry : results.entrySet()) {
-            String entryCaseID = entry.getKey();
-            double similarity = entry.getValue();
-            Case caze = new Case(concept, entryCaseID, similarity);
-            cases.add(caze.getCase());
+            try {
+                String entryCaseID = entry.getKey();
+                double similarity = entry.getValue();
+                Case caze = new Case(concept, entryCaseID, similarity);
+                cases.add(caze.getCase());
+            } catch (Exception e) {
+                // If we're here, we have a concept with an ID from a different concept. Case doesn't exist; continue
+            }
         }
-
         return cases;
     }
 }


### PR DESCRIPTION
This PR attempts to fix querying with multiple attributes, when these attributes can be subconcepts of the original concept.
This is done by creating a function which can be called recursively, i.e. if there's a subconcept within a subconcept within a concept etc.

The function is made to take an instance, and add attributes to the instance depending on the type.

We check if the attribute is of type `ConceptDesc`. After that, the first key is the subconcept ID, and the value is the instance. We then extract the instance key-value pairs, and call the function recursively to construct the instance of the subconcept.

Finally, the attribute (instance) is added to the original query, customized depending on whether it is multiple or not.

Note: all new changes are in `Query.java`. The other changes, are formatting of files.